### PR TITLE
use external library for influxdb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/aqi"]
 	path = lib/aqi
 	url = git@github.com:fardog/aqi-cpp.git
+[submodule "lib/influxdb"]
+	path = lib/influxdb
+	url = git@github.com:tobiasschuerg/InfluxDB-Client-for-Arduino.git

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Once configured, a webserver is exposed on port 80 which can be used to view
 sensor values, update firmware, change configuration, and reboot or reset the
 sensor.
 
+**Note:** earlier versions of Anton submitted values to InfluxDB as floats; this
+has been corrected to use integer values. Updating will require you to either
+use a new database or rewrite your existing one.
+
 ## Acknowledgements
 
 This was very quick to implement due to


### PR DESCRIPTION
although not yet supported, this will make influxdb2 support relatively trivial.

**note:** this changes the format of the samples sent to influxdb, which were being sent as floats, despite always being integer values. they are now sent correctly, but this can't be done to an existing anton db; you'll need to either rewrite the db, or start inserting into a new one.