### PR TITLE
report temperature as float; specify temperature offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+Changes which are not backwards compatible will be listed here. Anton is under
+active development and does not have a fixed feature set, nor does it have
+version numbers yet. For now, changes will be listed by date.
+
+## 2022-01-03
+
+To report more accurate temperatures, the following changes were made:
+
+* Temperature fields are now floats
+* A compile-time temperature offset may be provided, which is used by the BSEC
+  library to perform its calculations.
+
+### Temperature Fields
+
+Temperature fields are now floats; in previous versions they were integers,
+which loses a lot of precision when dealing in Celsius. To avoid conflicts
+with existing databases, fields were renamed/added:
+
+* `temperature` is now `temperature_c`
+* `temperature_c_raw` is the uncompensated temperature; direct from the sensor
+
+**Note:** `temperature_c_raw` is _not_ the same as "`temperature_c` ignoring
+offset", but rather the raw reading from the sensor itself. If you needed the
+previous equivalent `temperature` you should take `temperature_c` and remove the
+compiled offset from it, although there shouldn't be much use for this value.
+
+### Compile-time Temperature Offset
+
+When compiling Anton firmware, you may define the float value
+`BSEC_TEMPERATURE_OFFSET_C` which will be passed to the underlying [BSEC][bsec]
+library to determine the temperature offset that should be used. The default
+value of `4.0` works well for various 3D printable cases, and you may override
+it for your application as necessary.
+
+**Note:** This value is _subtracted_ from the values that are read; you will
+almost always wish to specify a positive value here.
+
+## 2021-12-12
+
+Move to Bosch Sensortec's [BSEC][bsec] library for the BME680, which improves
+accuracy of the temperature/humidity readings as well as provides equivalent CO₂
+values without the dedicated sensor. However this brings additional license
+restrictions which you should [view and accept][bosch] before using.
+
+[bsec]: https://github.com/BoschSensortec/BSEC-Arduino-library
+[bosch]: https://www.bosch-sensortec.com/software-tools/software/bsec/
+
+
+## 2021-09-25
+
+Does away with pin/UART configurations and makes them compile time. Also added
+CO₂ sensor options. This caused a revision of the configuration options, and you
+will need to reconfigure the sensor after flashing.
+
+## 2021-07-04
+
+Moves from [WifiManager][] to [IotWebConf][]. *This is a backwards incompatible
+change.* You will need to reconfigure the sensor after upgrading.
+
+[WifiManager]: https://github.com/tzapu/WiFiManager
+[IotWebConf]: https://github.com/prampec/IotWebConf
+
+## 2020-10-22
+
+Moved from the deprecated `SPIFFS` to the still-maintained `LittleFS`. *This is
+a backwards incompatible change.* You will need to reconfigure the sensor after
+upgrading.
+
+## 2020-10-03
+
+Earlier versions of Anton submitted values to InfluxDB as floats; this has been
+corrected to use integer values. Updating will require you to either use a new
+database or rewrite your existing one.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ sensor parts. It's not pretty or full featured but it works.
 [InfluxDB]: https://docs.influxdata.com/influxdb/v1.8/
 [Luftdaten]: https://sensor.community/
 
-**Note:** the current `main` branch will not be optimal if you are using the
-ZH03B particulate sensor. If you are, it's recommended you use the [tagged
-v1.0.0 release][v1.0.0].
-
-[v1.0.0]: https://github.com/fardog/anton/releases/tag/v1.0.0
-
 ## Requirements
 
 Hardware:
@@ -135,7 +129,8 @@ error, it will be omitted from the InfluxDB submission.
 If you have the optional multisensor connected, the following additional fields
 fields will be sent; all are integers unless noted:
 
-* `temperature` °C
+* `temperature_c` (float) °C
+* `temperature_c_raw` (float) °C, uncompensated
 * `humidity` %rh
 * `pressure` hPa
 * `gas_resistance` Ohm
@@ -179,35 +174,7 @@ sensor.
 
 ## Changelog
 
-Changes which are not backwards compatible will be listed here. Anton is under
-active development and does not have a fixed feature set, nor does it have
-version numbers yet. For now, changes will be listed by date.
-
-* **2021-12-12** Move to Bosch Sensortec's [BSEC][bsec] library for the BME680,
-  which improves accuracy of the temperature/humidity readings as well as
-  provides equivalent CO₂ values without the dedicated sensor. However this
-  brings additional license restrictions which you should [view and
-  accept][bosch] before using.
-
-* **2021-09-25** Does away with pin/UART configurations and makes them compile
-  time. Also added CO₂ sensor options. This caused a revision of the
-  configuration options, and you will need to reconfigure the sensor after
-  flashing.
-
-* **2021-07-04** Moves from [WifiManager][] to [IotWebConf][]. *This is a
-  backwards incompatible change.* You will need to reconfigure the sensor after
-  upgrading.
-
-* **2020-10-22** Moved from the deprecated `SPIFFS` to the still-maintained
-  `LittleFS`. *This is a backwards incompatible change.* You will need to
-  reconfigure the sensor after upgrading.
-
-* **2020-10-03** earlier versions of Anton submitted values to InfluxDB as
-  floats; this has been corrected to use integer values. Updating will require
-  you to either use a new database or rewrite your existing one.
-
-[WifiManager]: https://github.com/tzapu/WiFiManager
-[IotWebConf]: https://github.com/prampec/IotWebConf
+See [CHANGELOG](./CHANGELOG.md).
 
 ## Acknowledgements
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,10 @@
 #define PRODUCT_NAME "anton"
 #define DEFAULT_PASSWORD "anton-system"
 
+#ifndef BSEC_TEMPERATURE_OFFSET_C
+#define BSEC_TEMPERATURE_OFFSET_C 4.0
+#endif
+
 // pins
 #ifdef ESP8266
 #define PARTICULATE_RX D3
@@ -386,7 +390,7 @@ void setup()
   {
     Serial.println("setup: starting BME680 VOC sensor on I2C (default pins)");
     Wire.begin();
-    BME680_EnvironmentSensor *BME = new BME680_EnvironmentSensor(Wire);
+    BME680_EnvironmentSensor *BME = new BME680_EnvironmentSensor(Wire, BSEC_TEMPERATURE_OFFSET_C);
     environmentSensor = BME;
   }
 

--- a/src/reporters/InfluxDB_Reporter.cpp
+++ b/src/reporters/InfluxDB_Reporter.cpp
@@ -37,7 +37,8 @@ bool InfluxDB_Reporter::report(AirData *air, CalculatedAQI *aqi, EnvironmentData
 
   if (env)
   {
-    measurement.addField("temperature", util::rnd(env->tempC));
+    measurement.addField("temperature_c_raw", util::rnd(env->tempCRaw, 2));
+    measurement.addField("temperature_c", util::rnd(env->tempC, 2));
     measurement.addField("humidity", util::rnd(env->humPct));
     measurement.addField("pressure", util::rnd(env->pressure / 100.0));
     measurement.addField("gas_resistance", util::rnd(env->gasResistance / 100.0));

--- a/src/sensors/BME680_EnvironmentSensor.cpp
+++ b/src/sensors/BME680_EnvironmentSensor.cpp
@@ -1,10 +1,11 @@
 #include "BME680_EnvironmentSensor.h"
 
-BME680_EnvironmentSensor::BME680_EnvironmentSensor(TwoWire &i2c)
+BME680_EnvironmentSensor::BME680_EnvironmentSensor(TwoWire &i2c, float temperatureOffsetCelsius)
     : _sensor(Bsec())
 {
   _sensor.begin(BME680_I2C_ADDR_SECONDARY, i2c);
   _sensor.updateSubscription(_sensorList, 11, BSEC_SAMPLE_RATE_LP);
+  _sensor.setTemperatureOffset(temperatureOffsetCelsius);
 }
 
 bool BME680_EnvironmentSensor::getEnvironmentData(EnvironmentData *data)
@@ -27,7 +28,9 @@ void BME680_EnvironmentSensor::loop()
   {
     _ready = true;
     _data.tempC = _sensor.temperature;
+    _data.tempCRaw = _sensor.rawTemperature;
     _data.humPct = _sensor.humidity;
+    _data.humPctRaw = _sensor.rawHumidity;
     _data.pressure = _sensor.pressure;
     _data.gasResistance = _sensor.gasResistance;
     _data.iaq = _sensor.staticIaq;

--- a/src/sensors/BME680_EnvironmentSensor.h
+++ b/src/sensors/BME680_EnvironmentSensor.h
@@ -8,7 +8,7 @@
 class BME680_EnvironmentSensor : public EnvironmentSensor
 {
 public:
-  BME680_EnvironmentSensor(TwoWire &i2c);
+  BME680_EnvironmentSensor(TwoWire &i2c, float temperatureOffsetCelsius = 0.0);
   bool getEnvironmentData(EnvironmentData *data);
   void loop();
   String getLastError() { return _lastError; };

--- a/src/sensors/EnvironmentSensor.h
+++ b/src/sensors/EnvironmentSensor.h
@@ -4,7 +4,9 @@
 struct EnvironmentData
 {
   float tempC;
+  float tempCRaw;
   float humPct;
+  float humPctRaw;
   float pressure;
   float gasResistance;
   float iaq;


### PR DESCRIPTION
* report temperature as a float value
* allow compile-time specified temperature offset to be passed to BSEC
* move changelog into its own file

see the changelog for more detail, but this exposes a new float field for the temperature to avoid conflicting with the existing (removed) integer field